### PR TITLE
Add config flag to enable/disable JMX API

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ crate {
     enable_blobs: false,
     enable_rolling_upgrades: false,
     enable_master_data_deployment: false,
+    enable_jmx_api: false,
   },
 }
 ```

--- a/common.libsonnet
+++ b/common.libsonnet
@@ -12,9 +12,11 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     ],
 
     extraPorts:: [
-      containerPort.new(name='jmx', port=$._config.jmx_listen_port),
       containerPort.new(name='jmx-exporter', port=$._config.jmx_exporter_listen_port),
-    ],
+    ] + if $._config.enable_jmx_api then
+      [containerPort.new(name='jmx', port=$._config.jmx_listen_port)]
+    else
+      [],
 
     readinessProbe::
       container.mixin.readinessProbe.httpGet.withPath('/ready') +

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -51,6 +51,7 @@ local deployment = k.apps.v1.deployment;
     enable_blobs: false,
     enable_rolling_upgrades: false,
     enable_master_data_deployment: false,
+    enable_jmx_api: false,
 
     // crate.yml
     crate: {

--- a/statefulset.libsonnet
+++ b/statefulset.libsonnet
@@ -9,9 +9,16 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   local envVar = k.core.v1.envVar,
 
   newCrateContainer(args, cpu, mem, heap, dataVolumeMounts=[], containerName='crate')::
+    local flags =
+      k.util.mapToFlags($.common_args + args, prefix='-C') +
+      if $._config.enable_jmx_api then
+        k.util.mapToFlags($.jmx_args, prefix='-D')
+      else
+        [];
+
     container.new(containerName, $._images.crate) +
     container.withPorts($.util.defaultPorts + $.util.extraPorts) +
-    container.withArgsMixin(k.util.mapToFlags($.common_args + args, prefix='-C')) +
+    container.withArgsMixin(flags) +
     container.withVolumeMountsMixin(dataVolumeMounts) +
     container.withEnvMixin([
       envVar.new('CRATE_HEAP_SIZE', heap),
@@ -44,6 +51,15 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
   crate_ext_volume_mount::
     [volumeMount.new('ext', '/crate/ext')],
+
+  jmx_args:: {
+    'com.sun.management.jmxremote': '',
+    'com.sun.management.jmxremote.port': $._config.jmx_listen_port,
+    'com.sun.management.jmxremote.ssl': false,
+    'com.sun.management.jmxremote.authenticate': false,
+    'com.sun.management.jmxremote.rmi.port': $._config.jmx_listen_port,
+    'java.rmi.server.hostname': '${POD_NAME}',
+  },
 
   common_args:: {
     'path.conf': '/crate/config',


### PR DESCRIPTION
When JMX API is enabled via `$._config.enable_jmx_api` then the CLI arguments for the `crate` container are extended by the following:

```
-Dcom.sun.management.jmxremote
-Dcom.sun.management.jmxremote.port=$._config.jmx_listen_port
-Dcom.sun.management.jmxremote.ssl=false
-Dcom.sun.management.jmxremote.authenticate=false
-Dcom.sun.management.jmxremote.rmi.port=$._config.jmx_listen_port
-Djava.rmi.server.hostname=${POD_NAME}
```

As described in the official [CrateDB docs](https://crate.io/docs/crate/reference/en/5.4/admin/monitoring.html).

Additionally, the `Service` is extended with the TCP port specified in `$._config.jmx_listen_port`.