### PR TITLE
Use correct config path from $._config.config_mount_path

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -234,7 +234,7 @@ local deployment = k.apps.v1.deployment;
   },
 
   config_file:
-    configMap.new('crate') +
+    configMap.new($._config.config_mount_name) +
     configMap.withData({
       'crate.yml': k.util.manifestYaml($._config.crate),
       // 'log4j2.properties': $.util.toProperties($._config.log4j),

--- a/statefulset.libsonnet
+++ b/statefulset.libsonnet
@@ -46,7 +46,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     [volumeMount.new('ext', '/crate/ext')],
 
   common_args:: {
-    'path.conf': '/crate/config',
+    'path.conf': $._config.config_mount_path,
     'node.name': '${POD_NAME}',
     'node.attr.namespace': '${POD_NAMESPACE}',
   },


### PR DESCRIPTION
The `-Cpath.config` CLI flag was wrongly hard coded to `/crate/config` which caused the config to not be found if `$._config.config_mount_path` was set otherwise.