### PR TITLE
Add SQL exporter as sidecar container

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -46,12 +46,14 @@ local deployment = k.apps.v1.deployment;
     psql_listen_port: 5432,
     jmx_listen_port: 7979,
     jmx_exporter_listen_port: 8080,
+    sql_exporter_listen_port: 8181,
 
     // flags
     enable_blobs: false,
     enable_rolling_upgrades: false,
     enable_master_data_deployment: false,
     enable_jmx_api: false,
+    enable_sql_exporter: true,
 
     // crate.yml
     crate: {

--- a/images.libsonnet
+++ b/images.libsonnet
@@ -2,5 +2,6 @@
   _images+:: {
     crate: 'crate:%s' % [$._config.version],
     busybox: 'busybox:latest',
+    sql_exporter: 'githubfree/sql_exporter:latest',
   },
 }

--- a/main.libsonnet
+++ b/main.libsonnet
@@ -10,4 +10,5 @@
 + (import 'images.libsonnet')
 + (import 'common.libsonnet')
 + (import 'pvc.libsonnet')
++ (import 'sqlexporter.libsonnet')
 + (import 'statefulset.libsonnet')

--- a/sqlexporter.libsonnet
+++ b/sqlexporter.libsonnet
@@ -1,0 +1,104 @@
+local k = import 'ksonnet-util/kausal.libsonnet';
+
+{
+  local configMap = k.core.v1.configMap,
+  local container = k.core.v1.container,
+  local volumeMount = k.core.v1.volumeMount,
+
+  // TODO(chaudum): Should these be exposed in $._config object?
+  local mount_name = 'sql-exporter',
+  local mount_path = '/sql-exporter/config',
+
+  _config+:: {
+    sql_exporter: {
+      global: {
+        // Subtracted from Prometheus' scrape_timeout to give us some headroom and prevent Prometheus from
+        // timing out first.
+        scrape_timeout_offset: '500ms',
+        // Minimum interval between collector runs: by default (0s) collectors are executed on every scrape.
+        min_interval: '1s',
+        // Maximum number of open connections to any one target. Metric queries will run concurrently on
+        // multiple connections.
+        max_connections: 10,
+        // Maximum number of idle connections to any one target.
+        max_idle_connections: 3,
+      },
+      target: {
+        data_source_name: 'postgres://%s@localhost:%s?sslmode=disable' % ['crate', $._config.psql_listen_port],
+        collectors: [c.collector_name for c in $._config.sql_exporter_collectors],
+      },
+      collector_files: [
+        '*.collector.yml',
+      ],
+    },
+    sql_exporter_collectors: [
+      {
+        collector_name: 'default',
+        metrics: [
+          {
+            metric_name: 'crate_table_health',
+            type: 'gauge',
+            help: 'Table health (1=GREEN, 2=YELLOW, 3=RED)',
+            key_labels: ['schema', 'table'],
+            static_labels: {},
+            values: ['severity'],
+            query: |||
+              SELECT table_schema AS "schema", table_name AS "table", severity
+              FROM sys.health
+            |||,
+          },
+          {
+            metric_name: 'crate_table_shards_total',
+            type: 'gauge',
+            help: 'Underreplicated shards per table',
+            key_labels: ['schema', 'table'],
+            value_label: 'state',
+            static_labels: {},
+            values: ['underreplicated', 'missing'],
+            query: |||
+              SELECT table_schema AS "schema", table_name AS "table", missing_shards AS "missing", underreplicated_shards AS "underreplicated"
+              FROM sys.health
+            |||,
+          },
+          {
+            metric_name: 'crate_shards_total',
+            type: 'gauge',
+            help: 'Shard count by table and state',
+            key_labels: ['schema', 'table', 'state', 'primary'],
+            static_labels: {},
+            values: ['value'],
+            query: |||
+              SELECT COUNT(*) AS "value", schema_name AS "schema", table_name AS "table", LOWER(state) AS "state", "primary"
+              FROM sys.shards
+              GROUP BY "schema", "table", "state", "primary"
+            |||,
+          },
+        ],
+      },
+    ],
+  },
+
+  sql_exporter_args:: {
+    'config.file': '%s/config.yml' % mount_path,
+    'web.listen-address': ':%s' % $._config.sql_exporter_listen_port,
+    'web.metrics-path': '/metrics',
+  },
+
+  sql_exporter_container::
+    container.new(mount_name, $._images.sql_exporter) +
+    container.withArgsMixin(k.util.mapToFlags($.sql_exporter_args)) +
+    container.withVolumeMountsMixin([
+      volumeMount.new(mount_name, mount_path),
+    ]) +
+    k.util.resourcesRequests('500m', '128Mi') +
+    k.util.resourcesLimits('1000m', '256Mi') +
+    {},
+
+  sql_exporter_config_file:
+    configMap.new(mount_name) +
+    configMap.withData(
+      { 'config.yml': k.util.manifestYaml($._config.sql_exporter) }
+      + { ['%s.collector.yml' % collector.collector_name]: k.util.manifestYaml(collector) for collector in $._config.sql_exporter_collectors }
+    ),
+
+}


### PR DESCRIPTION
The [exporter](https://github.com/free/sql_exporter/tree/master) can expose Prometheus metrics from SQL statements executed against CrateDB.

The default collector config exposes metrics from the sys.health and sys.shards tables.

The SQL exporter is enabled by default and listens on port 8181.

---

**Update**: I think it would make more sense to run the SQL exporter as separate `Deployment`. The sidecar approach has the benefit of being able to use the `crate` user to connect to CrateDB. However, that means that all metrics are also exposed `n` times, where `n` is the number of CrateDB nodes. This is not desired.

**Running as a separate `Deployment` requires to bootstrap a dedicated CrateDB user with necessary permissions.**